### PR TITLE
Upgraded Gradle wrapper version to 5.6.4

### DIFF
--- a/lib/android/gradle/wrapper/gradle-wrapper.properties
+++ b/lib/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Although Gradle v6.0 has been released a few days ago, I upgraded to the latest version compatible with current react-native projects.

Gradle v6.0 has some break changes that might effects the project and it's not safe to use yet.